### PR TITLE
Updated readme for redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# This project is no longer actively maintained. Please see an additionally popular statsd client at: [https://github.com/reinh/statsd](https://github.com/reinh/statsd)
 statsd-client
 =============
 


### PR DESCRIPTION
I noticed that [etsy/statsd](https://github.com/etsy/statsd/wiki) still points to this repo; however, it appears that [reinh/statsd](https://github.com/reinh/statsd) is a more actively maintained and popular repo. 

Was wondering if it would be relevant to point your statsd library towards that one to unify the ruby community towards one active statsd-client.

I realize the nature of this pull request could come off as insulting, that's not my intensions at all. Was just wanting to take one step forward in helping ruby developers in using statsd.

Thank you!